### PR TITLE
Display full pipeline metadata in dashboard

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -262,8 +262,8 @@
 
     function buildSdkComparisonTable(dataset, sdkResults) {
       const entries = sdkResults
-        .filter(s => s.pipeline && s.pipeline[dataset])
-        .map(s => ({ id: s.id, name: s.name, data: s.pipeline[dataset] }));
+        .filter(s => s.pipeline?.datasets?.[dataset])
+        .map(s => ({ id: s.id, name: s.name, lang: s.pipeline.metadata?.language, data: s.pipeline.datasets[dataset] }));
 
       if (entries.length === 0) return null;
 
@@ -297,8 +297,17 @@
       thead.appendChild(headRow);
       table.appendChild(thead);
 
+      // Build union of all operations for this dataset
+      const opSet = new Set();
+      for (const e of entries) {
+        for (const op of Object.keys(e.data.operations || {})) opSet.add(op);
+      }
+      const ops = OPS.filter(op => opSet.has(op));
+      // Append any extra operations not in the canonical list
+      for (const op of opSet) { if (!ops.includes(op)) ops.push(op); }
+
       const tbody = document.createElement('tbody');
-      for (const op of OPS) {
+      for (const op of ops) {
         const tr = document.createElement('tr');
         const tdOp = document.createElement('td');
         tdOp.textContent = op;
@@ -349,27 +358,40 @@
       h2.textContent = sdk.name || sdk.id;
       header.appendChild(h2);
 
-      if (sdk.pipeline) {
+      const meta = sdk.pipeline?.metadata;
+      if (meta?.language) {
         const langBadge = document.createElement('span');
         langBadge.className = 'badge badge-lang';
-        // Infer language from the first dataset's metadata or id
-        const lang = sdk.id.includes('python') ? 'Python' :
-                     sdk.id.includes('golang') ? 'Go' :
-                     sdk.id.includes('csharp') ? 'C#' :
-                     sdk.id.includes('typescript') ? 'TypeScript' : '';
-        if (lang) {
-          langBadge.textContent = lang;
-          header.appendChild(langBadge);
-        }
+        langBadge.textContent = meta.language.charAt(0).toUpperCase() + meta.language.slice(1);
+        header.appendChild(langBadge);
       }
       card.appendChild(header);
 
       const body = document.createElement('div');
       body.className = 'sdk-body';
 
-      if (sdk.pipeline) {
+      // Metadata section (runtime, harness, package version)
+      if (meta) {
+        const metaSection = document.createElement('div');
+        metaSection.className = 'section';
+        const metaTitle = document.createElement('div');
+        metaTitle.className = 'section-title';
+        metaTitle.textContent = 'SDK Info';
+        metaSection.appendChild(metaTitle);
+
+        const metaGrid = document.createElement('div');
+        metaGrid.className = 'metric-grid';
+        if (meta.runtime_version) metaGrid.appendChild(metricBox('Runtime', meta.runtime_version));
+        if (meta.benchmark_harness) metaGrid.appendChild(metricBox('Harness', meta.benchmark_harness));
+        if (meta.sdk_package_version) metaGrid.appendChild(metricBox('Package Version', meta.sdk_package_version));
+        metaSection.appendChild(metaGrid);
+        body.appendChild(metaSection);
+      }
+
+      const datasets = sdk.pipeline?.datasets;
+      if (datasets) {
         for (const ds of DATASETS) {
-          const dsData = sdk.pipeline[ds];
+          const dsData = datasets[ds];
           if (!dsData?.operations) continue;
 
           const section = document.createElement('div');
@@ -383,7 +405,7 @@
           const grid = document.createElement('div');
           grid.className = 'metric-grid';
 
-          for (const op of OPS) {
+          for (const op of Object.keys(dsData.operations)) {
             const opData = dsData.operations[op];
             if (!opData) continue;
             grid.appendChild(metricBox(op + ' (mean)', fmtNs(opData.mean_ns)));
@@ -627,7 +649,13 @@
       app.appendChild(ts);
 
       // Backward compat: if old format (data.sdks), treat as server_benchmarks
-      const sdkResults = data.sdk_benchmarks || [];
+      const sdkResults = (data.sdk_benchmarks || []).map(s => {
+        // Normalize: if pipeline lacks .datasets key, it's the old format (pipeline IS datasets)
+        if (s.pipeline && !s.pipeline.datasets && !s.pipeline.schema_version) {
+          s.pipeline = { datasets: s.pipeline, metadata: {} };
+        }
+        return s;
+      });
       const serverResults = data.server_benchmarks || data.sdks || [];
 
       const tabBar = document.createElement('div');

--- a/scripts/aggregate.py
+++ b/scripts/aggregate.py
@@ -14,6 +14,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_RESULTS_DIR = REPO_ROOT / "results"
 DEFAULT_OUTPUT = REPO_ROOT / "dashboard" / "data" / "results.json"
+DEFAULT_KNOWN_SDKS = REPO_ROOT / "known-sdks.json"
 
 
 def read_json(path: Path):
@@ -28,15 +29,14 @@ def read_json(path: Path):
 # ── SDK (library) benchmarks ────────────────────────────────────────────
 
 
-def _build_sdk_entry(entry: Path) -> dict | None:
+def _build_sdk_entry(entry: Path, names: dict[str, str]) -> dict | None:
     """Build an SDK benchmark entry from a directory containing report.json."""
     report = read_json(entry / "report.json")
     if report is None:
         return None
 
     sdk_id = report.get("sdk_id", entry.name)
-    metadata = report.get("metadata", {})
-    name = metadata.get("name", entry.name)
+    name = names.get(sdk_id, report.get("metadata", {}).get("name", sdk_id))
 
     result: dict = {"id": sdk_id, "name": name}
 
@@ -44,9 +44,9 @@ def _build_sdk_entry(entry: Path) -> dict | None:
     if env:
         result["env"] = env
 
-    datasets = report.get("datasets")
-    if datasets is not None:
-        result["pipeline"] = datasets
+    # Store the full report (including metadata + datasets) so the dashboard
+    # can display language, runtime version, harness, and package version.
+    result["pipeline"] = report
 
     return result
 
@@ -54,17 +54,17 @@ def _build_sdk_entry(entry: Path) -> dict | None:
 # ── Server benchmarks ───────────────────────────────────────────────────
 
 
-def _build_server_entry(entry: Path) -> dict | None:
+def _build_server_entry(entry: Path, names: dict[str, str]) -> dict | None:
     """Build a server benchmark entry from a directory containing conformance_summary.json."""
     sdk_id = entry.name
     result: dict = {"id": sdk_id}
 
     env = read_json(entry / "env.json")
     if env:
-        result["name"] = env.get("sdk_name", sdk_id)
+        result["name"] = names.get(sdk_id, env.get("sdk_name", sdk_id))
         result["env"] = env
     else:
-        result["name"] = sdk_id
+        result["name"] = names.get(sdk_id, sdk_id)
 
     conformance = read_json(entry / "conformance_summary.json")
     if conformance is not None:
@@ -86,7 +86,20 @@ def _build_server_entry(entry: Path) -> dict | None:
 # ── Aggregation ─────────────────────────────────────────────────────────
 
 
-def aggregate(results_dir: Path) -> tuple[list[dict], list[dict]]:
+def _load_names(known_sdks: Path) -> dict[str, str]:
+    """Load id→name mapping from known-sdks.json."""
+    names: dict[str, str] = {}
+    try:
+        with open(known_sdks) as f:
+            ks = json.load(f)
+        for entry in ks.get("sdk_benchmarks", []) + ks.get("server_benchmarks", []):
+            names[entry["id"]] = entry.get("name", entry["id"])
+    except (FileNotFoundError, json.JSONDecodeError):
+        pass
+    return names
+
+
+def aggregate(results_dir: Path, known_sdks: Path) -> tuple[list[dict], list[dict]]:
     """Walk *results_dir* and classify each sub-directory as SDK or server.
 
     Returns (sdk_benchmarks, server_benchmarks).
@@ -97,22 +110,24 @@ def aggregate(results_dir: Path) -> tuple[list[dict], list[dict]]:
     if not results_dir.is_dir():
         return sdk_benchmarks, server_benchmarks
 
+    names = _load_names(known_sdks)
+
     for entry in sorted(results_dir.iterdir()):
         if not entry.is_dir():
             continue
 
         # Detection: report.json → SDK benchmark, conformance_summary.json → server
         if (entry / "report.json").exists():
-            sdk_entry = _build_sdk_entry(entry)
+            sdk_entry = _build_sdk_entry(entry, names)
             if sdk_entry is not None:
                 sdk_benchmarks.append(sdk_entry)
         elif (entry / "conformance_summary.json").exists():
-            server_entry = _build_server_entry(entry)
+            server_entry = _build_server_entry(entry, names)
             if server_entry is not None:
                 server_benchmarks.append(server_entry)
         else:
             # Fallback: treat directories with k6 or env data as server results
-            server_entry = _build_server_entry(entry)
+            server_entry = _build_server_entry(entry, names)
             if server_entry is not None:
                 server_benchmarks.append(server_entry)
 
@@ -129,9 +144,13 @@ def main():
         "--output", type=Path, default=DEFAULT_OUTPUT,
         help="Output path for aggregated JSON (default: dashboard/data/results.json)",
     )
+    parser.add_argument(
+        "--known-sdks", type=Path, default=DEFAULT_KNOWN_SDKS,
+        help="Path to known-sdks.json for name lookup (default: known-sdks.json)",
+    )
     args = parser.parse_args()
 
-    sdk_benchmarks, server_benchmarks = aggregate(args.results_dir)
+    sdk_benchmarks, server_benchmarks = aggregate(args.results_dir, args.known_sdks)
 
     output = {
         "generated_at": datetime.now(timezone.utc).isoformat(),

--- a/scripts/aggregate.py
+++ b/scripts/aggregate.py
@@ -94,7 +94,7 @@ def _load_names(known_sdks: Path) -> dict[str, str]:
             ks = json.load(f)
         for entry in ks.get("sdk_benchmarks", []) + ks.get("server_benchmarks", []):
             names[entry["id"]] = entry.get("name", entry["id"])
-    except (FileNotFoundError, json.JSONDecodeError):
+    except (FileNotFoundError, json.JSONDecodeError, KeyError):
         pass
     return names
 


### PR DESCRIPTION
## Summary
- **aggregate.py**: Store full `report.json` as `pipeline` (including `metadata` block with language, runtime version, harness, package version) instead of just `datasets`; add `--known-sdks` CLI arg for consistent name resolution from `known-sdks.json`
- **dashboard**: Use `pipeline.metadata.language` for language badges instead of fragile ID substring matching; add "SDK Info" section to detail cards showing runtime, harness, and package version; build comparison table operations dynamically from the union of all SDKs
- Backward compatible with old pipeline format (auto-normalizes on load)

## Test plan
- [ ] Run `python3 scripts/aggregate.py --results-dir /tmp/mock --output /tmp/results.json` with mock SDK + server results and verify output has `pipeline.metadata` and `pipeline.datasets`
- [ ] Open dashboard locally (`python3 -m http.server -d dashboard 8080`) and verify both tabs render
- [ ] Verify SDK detail cards show "SDK Info" section with runtime, harness, package version
- [ ] Verify comparison table shows "—" for operations missing from some SDKs
- [ ] Verify old-format `results.json` (pipeline without `.datasets` key) still renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added language badges to benchmark entries for improved clarity
  * Introduced SDK Info metadata section displaying runtime, harness, and package version details
  * Enhanced operation performance rendering with highlighted fastest mean times across entries

* **Bug Fixes**
  * Improved backward compatibility handling for existing benchmark data structures
  * Enhanced data normalization for consistent result processing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->